### PR TITLE
feat: add Slipstream DNS tunnel support alongside DNSTT

### DIFF
--- a/cmd/panel/client.go
+++ b/cmd/panel/client.go
@@ -1,8 +1,11 @@
 package panel
 
 import (
+	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net/url"
 	"os"
@@ -164,7 +167,7 @@ var clientDisableCmd = &cobra.Command{
 
 var clientExportCmd = &cobra.Command{
 	Use:   "export [username]",
-	Short: "Export client connection URL",
+	Short: "Export client connection info",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		username := args[0]
@@ -180,15 +183,38 @@ var clientExportCmd = &cobra.Command{
 		label, _ := cmd.Flags().GetString("label")
 		domain, _ := cmd.Flags().GetString("domain")
 		pubkey, _ := cmd.Flags().GetString("pubkey")
+		slipstreamDomain, _ := cmd.Flags().GetString("slipstream-domain")
+		slipstreamCert, _ := cmd.Flags().GetString("slipstream-cert")
 
 		if label == "" {
 			label = fmt.Sprintf("SSH %s", username)
 		}
 
 		sshConnectionURL := generateSSHURL(username, client.Password, host, port, token, label)
-		dnsttConnectionURL := generateDNSTTURL(label, domain, pubkey, username, client.Password)
 		fmt.Println(sshConnectionURL)
-		fmt.Println(dnsttConnectionURL)
+
+		if domain != "" && pubkey != "" {
+			dnsttConnectionURL := generateDNSTTURL(label, domain, pubkey, username, client.Password)
+			fmt.Println(dnsttConnectionURL)
+		}
+
+		if slipstreamDomain != "" {
+			fmt.Println()
+			fmt.Println("--- Slipstream Connection Info ---")
+			fmt.Printf("Domain:   %s\n", slipstreamDomain)
+			fmt.Printf("Username: %s\n", username)
+			fmt.Printf("Password: %s\n", client.Password)
+			fmt.Printf("Host:     %s\n", host)
+			fmt.Printf("Port:     %d\n", port)
+			if slipstreamCert != "" {
+				certFingerprint := readCertFingerprint(slipstreamCert)
+				if certFingerprint != "" {
+					fmt.Printf("Cert SHA256: %s\n", certFingerprint)
+				}
+			}
+			fmt.Println("---------------------------------")
+		}
+
 		return nil
 	},
 }
@@ -202,8 +228,10 @@ func init() {
 	clientExportCmd.Flags().Int("port", 2222, "SSH server port")
 	clientExportCmd.Flags().String("token", "", "Connection token/key")
 	clientExportCmd.Flags().String("label", "", "Connection label")
-	clientExportCmd.Flags().String("domain", "", "Dnstt domain")
-	clientExportCmd.Flags().String("pubkey", "", "Public key")
+	clientExportCmd.Flags().String("domain", "", "DNSTT domain")
+	clientExportCmd.Flags().String("pubkey", "", "DNSTT public key")
+	clientExportCmd.Flags().String("slipstream-domain", "", "Slipstream tunnel domain")
+	clientExportCmd.Flags().String("slipstream-cert", "", "Path to Slipstream TLS cert for fingerprint")
 
 	// Add subcommands
 	clientCmd.AddCommand(clientAddCmd)
@@ -269,4 +297,24 @@ func generateDNSTTURL(label, domain, pubkey, username, password string) string {
 	}
 
 	return "dns://" + base64.StdEncoding.EncodeToString(data)
+}
+
+func readCertFingerprint(certPath string) string {
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return ""
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return ""
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return ""
+	}
+
+	hash := sha256.Sum256(cert.Raw)
+	return fmt.Sprintf("%x", hash)
 }

--- a/cmd/panel/server.go
+++ b/cmd/panel/server.go
@@ -56,18 +56,39 @@ var serverCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		dnsDomains := parseDomains(dnsDomain)
-		if len(dnsDomains) == 0 {
-			return fmt.Errorf("at least one dns-domain is required")
-		}
 		dnsttAddr, err := cmd.Flags().GetString("dnstt-addr")
 		if err != nil {
 			return err
 		}
-		dnsttAddrs := parseDomains(dnsttAddr)
-		if len(dnsttAddrs) == 0 {
-			return fmt.Errorf("at least one dnstt-addr is required")
+		slipstreamDomain, err := cmd.Flags().GetString("slipstream-domain")
+		if err != nil {
+			return err
 		}
+		slipstreamAddr, err := cmd.Flags().GetString("slipstream-addr")
+		if err != nil {
+			return err
+		}
+
+		dnsDomains := parseDomains(dnsDomain)
+		dnsttAddrs := parseDomains(dnsttAddr)
+		slipstreamDomains := parseDomains(slipstreamDomain)
+		slipstreamAddrs := parseDomains(slipstreamAddr)
+
+		if len(dnsDomains) == 0 && len(slipstreamDomains) == 0 {
+			return fmt.Errorf("at least one dns-domain or slipstream-domain is required")
+		}
+
+		if len(dnsDomains) > 0 && len(dnsttAddrs) == 0 {
+			return fmt.Errorf("dnstt-addr is required when dns-domain is set")
+		}
+
+		if len(slipstreamDomains) > 0 && len(slipstreamAddrs) == 0 {
+			return fmt.Errorf("slipstream-addr is required when slipstream-domain is set")
+		}
+
+		// Merge all domains and backend addresses for the DNS dispatcher
+		allDomains := append(dnsDomains, slipstreamDomains...)
+		allAddrs := append(dnsttAddrs, slipstreamAddrs...)
 
 		if port == sshPort || port == socksPort || sshPort == socksPort {
 			return fmt.Errorf("port, ssh-port, and socks-port must be different values")
@@ -108,7 +129,7 @@ var serverCmd = &cobra.Command{
 			SSHPort:     sshPort,
 			SOCKSPort:   socksPort,
 		})
-		dnsDispatcher, err := dnsdispatcher.NewDnsDispatcher(dnsDomains, dnsttAddrs)
+		dnsDispatcher, err := dnsdispatcher.NewDnsDispatcher(allDomains, allAddrs)
 		if err != nil {
 			return fmt.Errorf("failed to initialize DNS dispatcher: %w", err)
 		}
@@ -116,7 +137,12 @@ var serverCmd = &cobra.Command{
 		log.Printf("Starting mixed SSH/SOCKS entrypoint on %s:%d", host, port)
 		log.Printf("Starting internal SSH server on %s:%d", host, sshPort)
 		log.Printf("Starting internal SOCKS5 server on %s:%d", host, socksPort)
-		log.Printf("Starting DNS dispatcher for domains: %s, forwarding to: %s", strings.Join(dnsDomains, ", "), strings.Join(dnsttAddrs, ", "))
+		if len(dnsDomains) > 0 {
+			log.Printf("Starting DNS dispatcher for DNSTT domains: %s → %s", strings.Join(dnsDomains, ", "), strings.Join(dnsttAddrs, ", "))
+		}
+		if len(slipstreamDomains) > 0 {
+			log.Printf("Starting DNS dispatcher for Slipstream domains: %s → %s", strings.Join(slipstreamDomains, ", "), strings.Join(slipstreamAddrs, ", "))
+		}
 		log.Printf("Database: %s", dbPath)
 		log.Printf("Host key: %s", hostKey)
 		log.Println("Press Ctrl+C to stop the server")
@@ -188,8 +214,10 @@ func init() {
 	serverCmd.Flags().String("host-key", "", "Path to SSH host key file (will be generated if not exists)")
 	serverCmd.Flags().Bool("regenerate-key", false, "Regenerate the host key even if it already exists")
 	serverCmd.Flags().Int("key-size", 2048, "RSA key size in bits")
-	serverCmd.Flags().String("dns-domain", "", "Domain(s) to handle DNS queries for, comma-separated (e.g., t.example.com, t2.example.com)")
-	serverCmd.Flags().String("dnstt-addr", "127.0.0.1:5300", "DNSTT backend address(es), comma-separated (e.g., 127.0.0.1:5300,127.0.0.1:5301)")
+	serverCmd.Flags().String("dns-domain", "", "DNSTT domain(s), comma-separated (e.g., t.example.com,t2.example.com)")
+	serverCmd.Flags().String("dnstt-addr", "", "DNSTT backend address(es), comma-separated (e.g., 127.0.0.1:5300,127.0.0.1:5301)")
+	serverCmd.Flags().String("slipstream-domain", "", "Slipstream domain(s), comma-separated (e.g., s.example.com)")
+	serverCmd.Flags().String("slipstream-addr", "", "Slipstream backend address(es), comma-separated (e.g., 127.0.0.1:5400)")
 }
 
 func parseDomains(value string) []string {

--- a/dnsdispatcher/dnsdispatcher.go
+++ b/dnsdispatcher/dnsdispatcher.go
@@ -19,11 +19,11 @@ type DnsDispatcher struct {
 }
 
 type domainRoute struct {
-	domain   string
-	dnsttUDP *net.UDPAddr
+	domain     string
+	backendUDP *net.UDPAddr
 }
 
-func NewDnsDispatcher(domains []string, dnsttAddrs []string) (*DnsDispatcher, error) {
+func NewDnsDispatcher(domains []string, backendAddrs []string) (*DnsDispatcher, error) {
 	normalizedDomains := make([]string, 0, len(domains))
 	for _, domain := range domains {
 		domain = strings.TrimSpace(strings.ToLower(domain))
@@ -40,8 +40,8 @@ func NewDnsDispatcher(domains []string, dnsttAddrs []string) (*DnsDispatcher, er
 		return nil, fmt.Errorf("at least one domain is required")
 	}
 
-	normalizedAddrs := make([]string, 0, len(dnsttAddrs))
-	for _, addr := range dnsttAddrs {
+	normalizedAddrs := make([]string, 0, len(backendAddrs))
+	for _, addr := range backendAddrs {
 		addr = strings.TrimSpace(addr)
 		if addr == "" {
 			continue
@@ -50,11 +50,11 @@ func NewDnsDispatcher(domains []string, dnsttAddrs []string) (*DnsDispatcher, er
 	}
 
 	if len(normalizedAddrs) == 0 {
-		return nil, fmt.Errorf("at least one dnstt address is required")
+		return nil, fmt.Errorf("at least one backend address is required")
 	}
 
 	if len(normalizedAddrs) != 1 && len(normalizedAddrs) != len(normalizedDomains) {
-		return nil, &net.AddrError{Err: "dnstt addr count must be 1 or match dns-domain count"}
+		return nil, &net.AddrError{Err: "backend addr count must be 1 or match domain count"}
 	}
 
 	routes := make([]domainRoute, 0, len(normalizedDomains))
@@ -64,12 +64,12 @@ func NewDnsDispatcher(domains []string, dnsttAddrs []string) (*DnsDispatcher, er
 			addr = normalizedAddrs[i]
 		}
 
-		dnsttUDP, err := net.ResolveUDPAddr("udp", addr)
+		backendUDP, err := net.ResolveUDPAddr("udp", addr)
 		if err != nil {
 			return nil, err
 		}
 
-		routes = append(routes, domainRoute{domain: domain, dnsttUDP: dnsttUDP})
+		routes = append(routes, domainRoute{domain: domain, backendUDP: backendUDP})
 	}
 
 	return &DnsDispatcher{routes: routes}, nil
@@ -106,7 +106,7 @@ func (d *DnsDispatcher) Start(ctx context.Context) error {
 func (d *DnsDispatcher) matchTarget(qName string) *net.UDPAddr {
 	for _, route := range d.routes {
 		if strings.HasSuffix(qName, route.domain) {
-			return route.dnsttUDP
+			return route.backendUDP
 		}
 	}
 	return nil

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 set -e
 
 DNSTT_URL="https://dnstt.network/dnstt-server-linux-amd64"
+SLIPSTREAM_URL="https://github.com/omid-official/slipstream-rust/releases/download/v0.1.0/slipstream-server-linux-amd64"
 LIBERSUITE_URL=$(curl -s https://api.github.com/repos/omid-official/libersuite-panel/releases/latest \
   | grep browser_download_url \
   | grep libersuite-panel-linux-amd64 \
@@ -11,94 +12,168 @@ LIBERSUITE_SH_URL="https://raw.githubusercontent.com/omid-official/libersuite-pa
 
 BASE_DIR="$HOME/libersuite"
 DNSTT_DIR="$BASE_DIR/dnstt"
+SLIPSTREAM_DIR="$BASE_DIR/slipstream"
 LIBER_DIR="$BASE_DIR/libersuite"
 CONF_FILE="$BASE_DIR/config.env"
 DNSTT_RUNNER="$DNSTT_DIR/dnstt-runner.sh"
+SLIPSTREAM_RUNNER="$SLIPSTREAM_DIR/slipstream-runner.sh"
 RUN_USER="$(whoami)"
 BIN_TARGET="/usr/local/bin/libersuite"
 
-read -rp "Enter domain(s), comma-separated (example: t.example.com,t.example2.com): " DOMAIN
-read -rp "Enter DNSTT listen port (default: 5300): " DNSTT_PORT
+# ─── Tunnel mode selection ────────────────────────────────────────────────────
+echo ""
+echo "Select tunnel mode:"
+echo "  1) DNSTT only"
+echo "  2) Slipstream only"
+echo "  3) Both DNSTT and Slipstream"
+read -rp "Choice [1/2/3] (default: 1): " TUNNEL_MODE
+TUNNEL_MODE="${TUNNEL_MODE:-1}"
+
+case "$TUNNEL_MODE" in
+  1) USE_DNSTT=true;  USE_SLIPSTREAM=false ;;
+  2) USE_DNSTT=false; USE_SLIPSTREAM=true  ;;
+  3) USE_DNSTT=true;  USE_SLIPSTREAM=true  ;;
+  *) echo "Invalid choice"; exit 1 ;;
+esac
+
+# ─── DNSTT domain(s) ─────────────────────────────────────────────────────────
+DOMAIN=""
+DOMAINS=()
+DNSTT_PORT="5300"
+DNSTT_ADDRS=""
+
+if $USE_DNSTT; then
+  read -rp "Enter DNSTT domain(s), comma-separated (e.g., t.example.com): " DOMAIN
+  read -rp "Enter DNSTT listen port (default: 5300): " DNSTT_PORT
+  DNSTT_PORT="${DNSTT_PORT:-5300}"
+
+  while IFS=',' read -ra RAW_DOMAINS; do
+    for raw_domain in "${RAW_DOMAINS[@]}"; do
+      trimmed="$(echo "$raw_domain" | xargs)"
+      if [[ -n "$trimmed" ]]; then
+        DOMAINS+=("$trimmed")
+      fi
+    done
+  done <<< "$DOMAIN"
+  DOMAIN="$(IFS=,; echo "${DOMAINS[*]}")"
+
+  if [[ ${#DOMAINS[@]} -eq 0 ]]; then
+    echo "At least one DNSTT domain is required"
+    exit 1
+  fi
+fi
+
+# ─── Slipstream domain(s) ────────────────────────────────────────────────────
+SLIPSTREAM_DOMAIN=""
+SLIPSTREAM_DOMAINS=()
+SLIPSTREAM_PORT="5400"
+SLIPSTREAM_ADDRS=""
+
+if $USE_SLIPSTREAM; then
+  read -rp "Enter Slipstream domain(s), comma-separated (e.g., s.example.com): " SLIPSTREAM_DOMAIN
+  read -rp "Enter Slipstream listen port (default: 5400): " SLIPSTREAM_PORT
+  SLIPSTREAM_PORT="${SLIPSTREAM_PORT:-5400}"
+
+  while IFS=',' read -ra RAW_DOMAINS; do
+    for raw_domain in "${RAW_DOMAINS[@]}"; do
+      trimmed="$(echo "$raw_domain" | xargs)"
+      if [[ -n "$trimmed" ]]; then
+        SLIPSTREAM_DOMAINS+=("$trimmed")
+      fi
+    done
+  done <<< "$SLIPSTREAM_DOMAIN"
+  SLIPSTREAM_DOMAIN="$(IFS=,; echo "${SLIPSTREAM_DOMAINS[*]}")"
+
+  if [[ ${#SLIPSTREAM_DOMAINS[@]} -eq 0 ]]; then
+    echo "At least one Slipstream domain is required"
+    exit 1
+  fi
+fi
+
+# ─── Common ports ─────────────────────────────────────────────────────────────
 read -rp "Enter Libersuite listen port (default: 2223): " LIBERSUITE_PORT
 read -rp "Enter internal SSH listen port (default: 2222): " SSH_PORT
 read -rp "Enter SOCKS5 listen port (default: 1080): " SOCKS_PORT
 
-DNSTT_PORT="${DNSTT_PORT:-5300}"
 LIBERSUITE_PORT="${LIBERSUITE_PORT:-2223}"
 SSH_PORT="${SSH_PORT:-2222}"
 SOCKS_PORT="${SOCKS_PORT:-1080}"
-
-DOMAINS=()
-while IFS=',' read -ra RAW_DOMAINS; do
-  for raw_domain in "${RAW_DOMAINS[@]}"; do
-    trimmed="$(echo "$raw_domain" | xargs)"
-    if [[ -n "$trimmed" ]]; then
-      DOMAINS+=("$trimmed")
-    fi
-  done
-done <<< "$DOMAIN"
-
-DOMAIN="$(IFS=,; echo "${DOMAINS[*]}")"
-
-if [[ ${#DOMAINS[@]} -eq 0 ]]; then
-  echo "At least one domain is required"
-  exit 1
-fi
 
 if [[ "$LIBERSUITE_PORT" == "$SSH_PORT" || "$LIBERSUITE_PORT" == "$SOCKS_PORT" || "$SSH_PORT" == "$SOCKS_PORT" ]]; then
   echo "Ports must be unique: libersuite, ssh, and socks cannot be the same"
   exit 1
 fi
 
-DNSTT_ADDRS=""
-for ((i = 0; i < ${#DOMAINS[@]}; i++)); do
-  dnstt_instance_port=$((DNSTT_PORT + i))
-  if [[ "$dnstt_instance_port" == "$LIBERSUITE_PORT" || "$dnstt_instance_port" == "$SSH_PORT" || "$dnstt_instance_port" == "$SOCKS_PORT" ]]; then
-    echo "DNSTT port $dnstt_instance_port conflicts with libersuite/ssh/socks"
-    exit 1
-  fi
+# ─── Build DNSTT addresses ───────────────────────────────────────────────────
+if $USE_DNSTT; then
+  for ((i = 0; i < ${#DOMAINS[@]}; i++)); do
+    dnstt_instance_port=$((DNSTT_PORT + i))
+    if [[ "$dnstt_instance_port" == "$LIBERSUITE_PORT" || "$dnstt_instance_port" == "$SSH_PORT" || "$dnstt_instance_port" == "$SOCKS_PORT" ]]; then
+      echo "DNSTT port $dnstt_instance_port conflicts with libersuite/ssh/socks"
+      exit 1
+    fi
 
-  if [[ -z "$DNSTT_ADDRS" ]]; then
-    DNSTT_ADDRS="127.0.0.1:$dnstt_instance_port"
-  else
-    DNSTT_ADDRS="$DNSTT_ADDRS,127.0.0.1:$dnstt_instance_port"
-  fi
-done
+    if [[ -z "$DNSTT_ADDRS" ]]; then
+      DNSTT_ADDRS="127.0.0.1:$dnstt_instance_port"
+    else
+      DNSTT_ADDRS="$DNSTT_ADDRS,127.0.0.1:$dnstt_instance_port"
+    fi
+  done
+fi
 
+# ─── Build Slipstream addresses ──────────────────────────────────────────────
+if $USE_SLIPSTREAM; then
+  for ((i = 0; i < ${#SLIPSTREAM_DOMAINS[@]}; i++)); do
+    slip_instance_port=$((SLIPSTREAM_PORT + i))
+    if [[ "$slip_instance_port" == "$LIBERSUITE_PORT" || "$slip_instance_port" == "$SSH_PORT" || "$slip_instance_port" == "$SOCKS_PORT" ]]; then
+      echo "Slipstream port $slip_instance_port conflicts with libersuite/ssh/socks"
+      exit 1
+    fi
+
+    if [[ -z "$SLIPSTREAM_ADDRS" ]]; then
+      SLIPSTREAM_ADDRS="127.0.0.1:$slip_instance_port"
+    else
+      SLIPSTREAM_ADDRS="$SLIPSTREAM_ADDRS,127.0.0.1:$slip_instance_port"
+    fi
+  done
+fi
+
+# ─── Create folders ──────────────────────────────────────────────────────────
 echo "[+] Creating folders..."
-mkdir -p "$DNSTT_DIR" "$LIBER_DIR"
+mkdir -p "$LIBER_DIR"
+$USE_DNSTT && mkdir -p "$DNSTT_DIR"
+$USE_SLIPSTREAM && mkdir -p "$SLIPSTREAM_DIR"
 
-echo "[+] Downloading dnstt..."
-cd "$DNSTT_DIR"
-curl -L "$DNSTT_URL" -o dnstt-server-linux-amd64
-chmod +x dnstt-server-linux-amd64
+# ─── Install DNSTT ───────────────────────────────────────────────────────────
+if $USE_DNSTT; then
+  echo "[+] Downloading dnstt..."
+  cd "$DNSTT_DIR"
+  curl -L "$DNSTT_URL" -o dnstt-server-linux-amd64
+  chmod +x dnstt-server-linux-amd64
 
-echo "[+] Generating a dsntt key pair"
-cd "$DNSTT_DIR"
-./dnstt-server-linux-amd64 -gen-key -privkey-file server.key -pubkey-file server.pub
+  echo "[+] Generating dnstt key pair..."
+  ./dnstt-server-linux-amd64 -gen-key -privkey-file server.key -pubkey-file server.pub
 
-echo "[+] Installing dnstt service..."
-
-cat > "$DNSTT_RUNNER" <<EOF
+  echo "[+] Installing dnstt service..."
+  cat > "$DNSTT_RUNNER" <<EOF
 #!/usr/bin/env bash
 set -e
 
 trap 'kill 0' INT TERM EXIT
 EOF
 
-for ((i = 0; i < ${#DOMAINS[@]}; i++)); do
-  dnstt_instance_port=$((DNSTT_PORT + i))
-  domain_name="${DOMAINS[$i]}"
-  echo "$DNSTT_DIR/dnstt-server-linux-amd64 -udp 127.0.0.1:$dnstt_instance_port -privkey-file $DNSTT_DIR/server.key $domain_name 127.0.0.1:$LIBERSUITE_PORT &" >> "$DNSTT_RUNNER"
-done
+  for ((i = 0; i < ${#DOMAINS[@]}; i++)); do
+    dnstt_instance_port=$((DNSTT_PORT + i))
+    domain_name="${DOMAINS[$i]}"
+    echo "$DNSTT_DIR/dnstt-server-linux-amd64 -udp 127.0.0.1:$dnstt_instance_port -privkey-file $DNSTT_DIR/server.key $domain_name 127.0.0.1:$LIBERSUITE_PORT &" >> "$DNSTT_RUNNER"
+  done
 
-cat >> "$DNSTT_RUNNER" <<EOF
+  cat >> "$DNSTT_RUNNER" <<EOF
 wait -n
 EOF
+  chmod +x "$DNSTT_RUNNER"
 
-chmod +x "$DNSTT_RUNNER"
-
-sudo tee /etc/systemd/system/dnstt.service > /dev/null <<EOF
+  sudo tee /etc/systemd/system/dnstt.service > /dev/null <<EOF
 [Unit]
 Description=DNSTT Service (multi-domain)
 After=network.target
@@ -113,14 +188,141 @@ WorkingDirectory=$DNSTT_DIR
 WantedBy=multi-user.target
 EOF
 
-sudo systemctl daemon-reload
-sudo systemctl enable dnstt
-sudo systemctl start dnstt
+  sudo systemctl daemon-reload
+  sudo systemctl enable dnstt
+  sudo systemctl start dnstt
+fi
 
+# ─── Install Slipstream ──────────────────────────────────────────────────────
+if $USE_SLIPSTREAM; then
+  echo "[+] Downloading slipstream-server..."
+  cd "$SLIPSTREAM_DIR"
+  curl -L "$SLIPSTREAM_URL" -o slipstream-server
+  chmod +x slipstream-server
+
+  echo "[+] Generating Slipstream TLS certificate..."
+  openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+    -nodes -keyout "$SLIPSTREAM_DIR/key.pem" -out "$SLIPSTREAM_DIR/cert.pem" \
+    -days 3650 -subj "/CN=slipstream" 2>/dev/null
+  chmod 600 "$SLIPSTREAM_DIR/key.pem"
+
+  echo "[+] Installing slipstream service..."
+  cat > "$SLIPSTREAM_RUNNER" <<EOF
+#!/usr/bin/env bash
+set -e
+
+trap 'kill 0' INT TERM EXIT
+EOF
+
+  for ((i = 0; i < ${#SLIPSTREAM_DOMAINS[@]}; i++)); do
+    slip_instance_port=$((SLIPSTREAM_PORT + i))
+    slip_domain="${SLIPSTREAM_DOMAINS[$i]}"
+    echo "$SLIPSTREAM_DIR/slipstream-server --dns-listen-host 127.0.0.1 --dns-listen-port $slip_instance_port --domain $slip_domain --cert $SLIPSTREAM_DIR/cert.pem --key $SLIPSTREAM_DIR/key.pem --target-address 127.0.0.1:$LIBERSUITE_PORT &" >> "$SLIPSTREAM_RUNNER"
+  done
+
+  cat >> "$SLIPSTREAM_RUNNER" <<EOF
+wait -n
+EOF
+  chmod +x "$SLIPSTREAM_RUNNER"
+
+  sudo tee /etc/systemd/system/slipstream.service > /dev/null <<EOF
+[Unit]
+Description=Slipstream Service (multi-domain)
+After=network.target
+
+[Service]
+ExecStart=$SLIPSTREAM_RUNNER
+Restart=always
+User=$RUN_USER
+WorkingDirectory=$SLIPSTREAM_DIR
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable slipstream
+  sudo systemctl start slipstream
+
+  echo "[+] Installing slipstream watchdog..."
+  cat > "$SLIPSTREAM_DIR/watchdog.sh" <<'WATCHDOG_EOF'
+#!/usr/bin/env bash
+# Slipstream watchdog: checks each instance port with a DNS probe.
+# If any port is unresponsive, restart the slipstream service.
+
+CONF_FILE="$HOME/libersuite/config.env"
+[[ -f "$CONF_FILE" ]] && source "$CONF_FILE"
+
+SLIPSTREAM_PORT="${SLIPSTREAM_PORT:-5400}"
+SLIPSTREAM_DOMAIN="${SLIPSTREAM_DOMAIN:-}"
+
+if [[ -z "$SLIPSTREAM_DOMAIN" ]]; then
+  exit 0
+fi
+
+IFS=',' read -ra DOMAINS <<< "$SLIPSTREAM_DOMAIN"
+FAIL=0
+
+for ((i = 0; i < ${#DOMAINS[@]}; i++)); do
+  port=$((SLIPSTREAM_PORT + i))
+  domain="${DOMAINS[$i]}"
+
+  # Send a DNS A query to the slipstream port. We expect *some* response
+  # (even SERVFAIL or REFUSED means the process is alive).
+  if ! dig +short +timeout=5 +tries=1 "@127.0.0.1" -p "$port" "$domain" A >/dev/null 2>&1; then
+    echo "[watchdog] slipstream port $port ($domain) unresponsive"
+    FAIL=1
+  fi
+done
+
+if [[ "$FAIL" -eq 1 ]]; then
+  echo "[watchdog] restarting slipstream service..."
+  systemctl restart slipstream
+fi
+WATCHDOG_EOF
+  chmod +x "$SLIPSTREAM_DIR/watchdog.sh"
+
+  sudo tee /etc/systemd/system/slipstream-watchdog.service > /dev/null <<EOF
+[Unit]
+Description=Slipstream Watchdog Health Check
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=$SLIPSTREAM_DIR/watchdog.sh
+EOF
+
+  sudo tee /etc/systemd/system/slipstream-watchdog.timer > /dev/null <<EOF
+[Unit]
+Description=Run Slipstream Watchdog every 2 minutes
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=120
+
+[Install]
+WantedBy=timers.target
+EOF
+
+  sudo systemctl daemon-reload
+  sudo systemctl enable slipstream-watchdog.timer
+  sudo systemctl start slipstream-watchdog.timer
+fi
+
+# ─── Install Libersuite panel ────────────────────────────────────────────────
 echo "[+] Downloading libersuite..."
 cd "$LIBER_DIR"
 curl -L "$LIBERSUITE_URL" -o panel
 chmod +x panel
+
+# Build panel server flags
+PANEL_FLAGS="--port $LIBERSUITE_PORT --ssh-port $SSH_PORT --socks-port $SOCKS_PORT"
+if $USE_DNSTT; then
+  PANEL_FLAGS="$PANEL_FLAGS --dns-domain $DOMAIN --dnstt-addr $DNSTT_ADDRS"
+fi
+if $USE_SLIPSTREAM; then
+  PANEL_FLAGS="$PANEL_FLAGS --slipstream-domain $SLIPSTREAM_DOMAIN --slipstream-addr $SLIPSTREAM_ADDRS"
+fi
 
 echo "[+] Installing libersuite panel service..."
 sudo tee /etc/systemd/system/libersuite.service > /dev/null <<EOF
@@ -130,7 +332,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=$LIBER_DIR/panel server --port $LIBERSUITE_PORT --ssh-port $SSH_PORT --socks-port $SOCKS_PORT --dns-domain $DOMAIN --dnstt-addr $DNSTT_ADDRS
+ExecStart=$LIBER_DIR/panel server $PANEL_FLAGS
 Restart=always
 RestartSec=3
 User=$RUN_USER
@@ -155,13 +357,27 @@ echo "libersuite command installed"
 
 echo "[+] Saving config..."
 cat > "$CONF_FILE" <<EOF
+TUNNEL_MODE="$TUNNEL_MODE"
 DOMAIN="$DOMAIN"
 DNSTT_PORT="$DNSTT_PORT"
 DNSTT_ADDRS="$DNSTT_ADDRS"
+SLIPSTREAM_DOMAIN="$SLIPSTREAM_DOMAIN"
+SLIPSTREAM_PORT="$SLIPSTREAM_PORT"
+SLIPSTREAM_ADDRS="$SLIPSTREAM_ADDRS"
 LIBERSUITE_PORT="$LIBERSUITE_PORT"
 SSH_PORT="$SSH_PORT"
 SOCKS_PORT="$SOCKS_PORT"
 EOF
 
-
+echo ""
 echo "[+] Done."
+if $USE_DNSTT; then
+  echo "    DNSTT domains: $DOMAIN"
+  echo "    DNSTT pubkey:  $(cat "$DNSTT_DIR/server.pub" 2>/dev/null || echo 'N/A')"
+fi
+if $USE_SLIPSTREAM; then
+  echo "    Slipstream domains: $SLIPSTREAM_DOMAIN"
+  CERT_FP=$(openssl x509 -noout -fingerprint -sha256 -in "$SLIPSTREAM_DIR/cert.pem" 2>/dev/null | cut -d= -f2)
+  echo "    Slipstream cert SHA256: $CERT_FP"
+fi
+echo "    Panel port: $LIBERSUITE_PORT"

--- a/libersuite.sh
+++ b/libersuite.sh
@@ -3,15 +3,21 @@ set -e
 
 BASE_DIR="$HOME/libersuite"
 DNSTT_DIR="$BASE_DIR/dnstt"
+SLIPSTREAM_DIR="$BASE_DIR/slipstream"
 LIBER_DIR="$BASE_DIR/libersuite"
 CONF_FILE="$BASE_DIR/config.env"
 BIN_TARGET="/usr/local/bin/libersuite"
 DNSTT_RUNNER="$DNSTT_DIR/dnstt-runner.sh"
+SLIPSTREAM_RUNNER="$SLIPSTREAM_DIR/slipstream-runner.sh"
 
 DNSTT_SERVICE="/etc/systemd/system/dnstt.service"
+SLIPSTREAM_SERVICE="/etc/systemd/system/slipstream.service"
+SLIPSTREAM_WATCHDOG_SERVICE="/etc/systemd/system/slipstream-watchdog.service"
+SLIPSTREAM_WATCHDOG_TIMER="/etc/systemd/system/slipstream-watchdog.timer"
 LIBER_SERVICE="/etc/systemd/system/libersuite.service"
 
 DNSTT_BIN="$DNSTT_DIR/dnstt-server-linux-amd64"
+SLIPSTREAM_BIN="$SLIPSTREAM_DIR/slipstream-server"
 LIBER_BIN="$LIBER_DIR/panel"
 
 INSTALL_URL="https://raw.githubusercontent.com/omid-official/libersuite-panel/main/install.sh"
@@ -56,16 +62,30 @@ need_root() {
 load_conf() {
   if [[ -f "$CONF_FILE" ]]; then
     source "$CONF_FILE"
+    # Default TUNNEL_MODE for configs created before slipstream support
+    TUNNEL_MODE="${TUNNEL_MODE:-1}"
   else
     err "Config not found. Run: libersuite install"
   fi
 }
 
+use_dnstt() {
+  [[ "$TUNNEL_MODE" == "1" || "$TUNNEL_MODE" == "3" ]]
+}
+
+use_slipstream() {
+  [[ "$TUNNEL_MODE" == "2" || "$TUNNEL_MODE" == "3" ]]
+}
+
 save_conf() {
   cat > "$CONF_FILE" <<EOF
+TUNNEL_MODE="$TUNNEL_MODE"
 DOMAIN="$DOMAIN"
 DNSTT_PORT="$DNSTT_PORT"
 DNSTT_ADDRS="$DNSTT_ADDRS"
+SLIPSTREAM_DOMAIN="$SLIPSTREAM_DOMAIN"
+SLIPSTREAM_PORT="$SLIPSTREAM_PORT"
+SLIPSTREAM_ADDRS="$SLIPSTREAM_ADDRS"
 LIBERSUITE_PORT="$LIBERSUITE_PORT"
 SSH_PORT="$SSH_PORT"
 SOCKS_PORT="$SOCKS_PORT"
@@ -96,6 +116,30 @@ build_dnstt_addrs() {
   done
 }
 
+parse_slipstream_domains() {
+  SLIPSTREAM_DOMAINS=()
+  while IFS=',' read -ra RAW_DOMAINS; do
+    for raw_domain in "${RAW_DOMAINS[@]}"; do
+      trimmed="$(echo "$raw_domain" | xargs)"
+      if [[ -n "$trimmed" ]]; then
+        SLIPSTREAM_DOMAINS+=("$trimmed")
+      fi
+    done
+  done <<< "$SLIPSTREAM_DOMAIN"
+}
+
+build_slipstream_addrs() {
+  SLIPSTREAM_ADDRS=""
+  for ((i = 0; i < ${#SLIPSTREAM_DOMAINS[@]}; i++)); do
+    slip_instance_port=$((SLIPSTREAM_PORT + i))
+    if [[ -z "$SLIPSTREAM_ADDRS" ]]; then
+      SLIPSTREAM_ADDRS="127.0.0.1:$slip_instance_port"
+    else
+      SLIPSTREAM_ADDRS="$SLIPSTREAM_ADDRS,127.0.0.1:$slip_instance_port"
+    fi
+  done
+}
+
 write_dnstt_runner() {
   cat > "$DNSTT_RUNNER" <<EOF
 #!/usr/bin/env bash
@@ -117,16 +161,93 @@ EOF
   chmod +x "$DNSTT_RUNNER"
 }
 
+write_slipstream_runner() {
+  mkdir -p "$SLIPSTREAM_DIR"
+
+  cat > "$SLIPSTREAM_RUNNER" <<EOF
+#!/usr/bin/env bash
+set -e
+
+trap 'kill 0' INT TERM EXIT
+EOF
+
+  for ((i = 0; i < ${#SLIPSTREAM_DOMAINS[@]}; i++)); do
+    slip_instance_port=$((SLIPSTREAM_PORT + i))
+    slip_domain="${SLIPSTREAM_DOMAINS[$i]}"
+    echo "$SLIPSTREAM_BIN --dns-listen-host 127.0.0.1 --dns-listen-port $slip_instance_port --domain $slip_domain --cert $SLIPSTREAM_DIR/cert.pem --key $SLIPSTREAM_DIR/key.pem --target-address 127.0.0.1:$LIBERSUITE_PORT &" >> "$SLIPSTREAM_RUNNER"
+  done
+
+  cat >> "$SLIPSTREAM_RUNNER" <<EOF
+wait -n
+EOF
+
+  chmod +x "$SLIPSTREAM_RUNNER"
+}
+
+write_slipstream_watchdog() {
+  mkdir -p "$SLIPSTREAM_DIR"
+
+  cat > "$SLIPSTREAM_DIR/watchdog.sh" <<'WATCHDOG_EOF'
+#!/usr/bin/env bash
+# Slipstream watchdog: probes each instance port with a DNS query.
+# If any port is unresponsive, restart the slipstream service.
+
+CONF_FILE="$HOME/libersuite/config.env"
+[[ -f "$CONF_FILE" ]] && source "$CONF_FILE"
+
+SLIPSTREAM_PORT="${SLIPSTREAM_PORT:-5400}"
+SLIPSTREAM_DOMAIN="${SLIPSTREAM_DOMAIN:-}"
+
+if [[ -z "$SLIPSTREAM_DOMAIN" ]]; then
+  exit 0
+fi
+
+IFS=',' read -ra DOMAINS <<< "$SLIPSTREAM_DOMAIN"
+FAIL=0
+
+for ((i = 0; i < ${#DOMAINS[@]}; i++)); do
+  port=$((SLIPSTREAM_PORT + i))
+  domain="${DOMAINS[$i]}"
+
+  # Send a DNS A query. Any response (even SERVFAIL/REFUSED) means alive.
+  if ! dig +short +timeout=5 +tries=1 "@127.0.0.1" -p "$port" "$domain" A >/dev/null 2>&1; then
+    echo "[watchdog] slipstream port $port ($domain) unresponsive"
+    FAIL=1
+  fi
+done
+
+if [[ "$FAIL" -eq 1 ]]; then
+  echo "[watchdog] restarting slipstream service..."
+  systemctl restart slipstream
+fi
+WATCHDOG_EOF
+  chmod +x "$SLIPSTREAM_DIR/watchdog.sh"
+}
+
 rewrite_services() {
   need_root
   load_conf
   parse_domains
+  parse_slipstream_domains
 
-  if [[ ${#DOMAINS[@]} -eq 0 ]]; then
-    err "At least one domain is required"
+  if ! use_dnstt && ! use_slipstream; then
+    err "No tunnel mode configured. At least one of DNSTT or Slipstream is required."
   fi
 
-  DOMAIN="$(IFS=,; echo "${DOMAINS[*]}")"
+  if use_dnstt && [[ ${#DOMAINS[@]} -eq 0 ]]; then
+    err "At least one DNSTT domain is required"
+  fi
+
+  if use_slipstream && [[ ${#SLIPSTREAM_DOMAINS[@]} -eq 0 ]]; then
+    err "At least one Slipstream domain is required"
+  fi
+
+  if use_dnstt; then
+    DOMAIN="$(IFS=,; echo "${DOMAINS[*]}")"
+  fi
+  if use_slipstream; then
+    SLIPSTREAM_DOMAIN="$(IFS=,; echo "${SLIPSTREAM_DOMAINS[*]}")"
+  fi
 
   info "Rewriting systemd services..."
 
@@ -134,17 +255,17 @@ rewrite_services() {
     err "Ports must be unique: libersuite, ssh, and socks cannot be the same"
   fi
 
-  for ((i = 0; i < ${#DOMAINS[@]}; i++)); do
-    dnstt_instance_port=$((DNSTT_PORT + i))
-    if [[ "$dnstt_instance_port" == "$LIBERSUITE_PORT" || "$dnstt_instance_port" == "$SSH_PORT" || "$dnstt_instance_port" == "$SOCKS_PORT" ]]; then
-      err "DNSTT port $dnstt_instance_port conflicts with libersuite/ssh/socks"
-    fi
-  done
+  if use_dnstt; then
+    for ((i = 0; i < ${#DOMAINS[@]}; i++)); do
+      dnstt_instance_port=$((DNSTT_PORT + i))
+      if [[ "$dnstt_instance_port" == "$LIBERSUITE_PORT" || "$dnstt_instance_port" == "$SSH_PORT" || "$dnstt_instance_port" == "$SOCKS_PORT" ]]; then
+        err "DNSTT port $dnstt_instance_port conflicts with libersuite/ssh/socks"
+      fi
+    done
+    build_dnstt_addrs
+    write_dnstt_runner
 
-  build_dnstt_addrs
-  write_dnstt_runner
-
-  tee "$DNSTT_SERVICE" > /dev/null <<EOF
+    tee "$DNSTT_SERVICE" > /dev/null <<EOF
 [Unit]
 Description=DNSTT Service (multi-domain)
 After=network.target
@@ -158,6 +279,66 @@ WorkingDirectory=$DNSTT_DIR
 [Install]
 WantedBy=multi-user.target
 EOF
+  fi
+
+  if use_slipstream; then
+    for ((i = 0; i < ${#SLIPSTREAM_DOMAINS[@]}; i++)); do
+      slip_instance_port=$((SLIPSTREAM_PORT + i))
+      if [[ "$slip_instance_port" == "$LIBERSUITE_PORT" || "$slip_instance_port" == "$SSH_PORT" || "$slip_instance_port" == "$SOCKS_PORT" ]]; then
+        err "Slipstream port $slip_instance_port conflicts with libersuite/ssh/socks"
+      fi
+    done
+    build_slipstream_addrs
+    write_slipstream_runner
+
+    tee "$SLIPSTREAM_SERVICE" > /dev/null <<EOF
+[Unit]
+Description=Slipstream Service (multi-domain)
+After=network.target
+
+[Service]
+ExecStart=$SLIPSTREAM_RUNNER
+Restart=always
+User=$(whoami)
+WorkingDirectory=$SLIPSTREAM_DIR
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    write_slipstream_watchdog
+
+    tee "$SLIPSTREAM_WATCHDOG_SERVICE" > /dev/null <<EOF
+[Unit]
+Description=Slipstream Watchdog Health Check
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=$SLIPSTREAM_DIR/watchdog.sh
+EOF
+
+    tee "$SLIPSTREAM_WATCHDOG_TIMER" > /dev/null <<EOF
+[Unit]
+Description=Run Slipstream Watchdog every 2 minutes
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=120
+
+[Install]
+WantedBy=timers.target
+EOF
+  fi
+
+  # Build panel server flags
+  PANEL_FLAGS="--port $LIBERSUITE_PORT --ssh-port $SSH_PORT --socks-port $SOCKS_PORT"
+  if use_dnstt; then
+    PANEL_FLAGS="$PANEL_FLAGS --dns-domain $DOMAIN --dnstt-addr $DNSTT_ADDRS"
+  fi
+  if use_slipstream; then
+    PANEL_FLAGS="$PANEL_FLAGS --slipstream-domain $SLIPSTREAM_DOMAIN --slipstream-addr $SLIPSTREAM_ADDRS"
+  fi
 
   tee "$LIBER_SERVICE" > /dev/null <<EOF
 [Unit]
@@ -165,7 +346,7 @@ Description=Libersuite Panel
 After=network.target
 
 [Service]
-ExecStart=$LIBER_BIN server --port $LIBERSUITE_PORT --ssh-port $SSH_PORT --socks-port $SOCKS_PORT --dns-domain $DOMAIN --dnstt-addr $DNSTT_ADDRS
+ExecStart=$LIBER_BIN server $PANEL_FLAGS
 Restart=always
 User=$(whoami)
 WorkingDirectory=$LIBER_DIR
@@ -175,7 +356,20 @@ WantedBy=multi-user.target
 EOF
 
   systemctl daemon-reload
+  if use_slipstream; then
+    systemctl enable slipstream-watchdog.timer 2>/dev/null || true
+    systemctl start slipstream-watchdog.timer 2>/dev/null || true
+  fi
   ok "Services updated"
+}
+
+# ===== Helper: list active tunnel services =====
+tunnel_services() {
+  local svcs="libersuite"
+  load_conf 2>/dev/null || true
+  use_dnstt && svcs="$svcs dnstt"
+  use_slipstream && svcs="$svcs slipstream"
+  echo "$svcs"
 }
 
 # ===== Commands =====
@@ -192,24 +386,47 @@ update() {
 
 uninstall() {
   need_root
-  systemctl stop dnstt libersuite 2>/dev/null || true
-  systemctl disable dnstt libersuite 2>/dev/null || true
-  rm -f "$DNSTT_SERVICE" "$LIBER_SERVICE"
+  systemctl stop slipstream-watchdog.timer dnstt slipstream libersuite 2>/dev/null || true
+  systemctl disable slipstream-watchdog.timer dnstt slipstream libersuite 2>/dev/null || true
+  rm -f "$DNSTT_SERVICE" "$SLIPSTREAM_SERVICE" "$SLIPSTREAM_WATCHDOG_SERVICE" "$SLIPSTREAM_WATCHDOG_TIMER" "$LIBER_SERVICE"
   rm -f "$BIN_TARGET"
   systemctl daemon-reload
-  rm -r "$BASE_DIR"
+  rm -rf "$BASE_DIR"
   ok "Uninstalled successfully"
 }
 
 set_domain() {
   load_conf
-  DOMAIN="$1"
-  [[ -z "$DOMAIN" ]] && err "Usage: libersuite domain <t.example.com[,t.example2.com,...]>"
-  parse_domains
-  DOMAIN="$(IFS=,; echo "${DOMAINS[*]}")"
+  local target="$1"
+  local value="$2"
+
+  case "$target" in
+    dnstt)
+      [[ -z "$value" ]] && err "Usage: libersuite domain dnstt <t.example.com[,t2.example.com]>"
+      DOMAIN="$value"
+      parse_domains
+      DOMAIN="$(IFS=,; echo "${DOMAINS[*]}")"
+      ;;
+    slipstream)
+      [[ -z "$value" ]] && err "Usage: libersuite domain slipstream <s.example.com[,s2.example.com]>"
+      SLIPSTREAM_DOMAIN="$value"
+      parse_slipstream_domains
+      SLIPSTREAM_DOMAIN="$(IFS=,; echo "${SLIPSTREAM_DOMAINS[*]}")"
+      ;;
+    *)
+      # Legacy: treat as dnstt domain for backward compatibility
+      [[ -z "$target" ]] && err "Usage: libersuite domain <dnstt|slipstream> <domain(s)>"
+      DOMAIN="$target"
+      parse_domains
+      DOMAIN="$(IFS=,; echo "${DOMAINS[*]}")"
+      ;;
+  esac
+
   save_conf
   rewrite_services
-  systemctl restart dnstt libersuite
+  for svc in $(tunnel_services); do
+    systemctl restart "$svc" 2>/dev/null || true
+  done
   ok "Domain updated"
 }
 
@@ -225,18 +442,24 @@ set_ports() {
   fi
   save_conf
   rewrite_services
-  systemctl restart dnstt libersuite
+  for svc in $(tunnel_services); do
+    systemctl restart "$svc" 2>/dev/null || true
+  done
   ok "Ports updated"
 }
 
-start()   { need_root; systemctl start dnstt libersuite; ok "Started"; }
-stop()    { need_root; systemctl stop dnstt libersuite; ok "Stopped"; }
-restart() { need_root; systemctl restart dnstt libersuite; ok "Restarted"; }
-enable()  { need_root; systemctl enable dnstt libersuite; ok "Enabled at boot"; }
-disable() { need_root; systemctl disable dnstt libersuite; ok "Disabled at boot"; }
+start()   { need_root; for svc in $(tunnel_services); do systemctl start "$svc"; done; ok "Started"; }
+stop()    { need_root; for svc in $(tunnel_services); do systemctl stop "$svc"; done; ok "Stopped"; }
+restart() { need_root; for svc in $(tunnel_services); do systemctl restart "$svc"; done; ok "Restarted"; }
+enable()  { need_root; for svc in $(tunnel_services); do systemctl enable "$svc"; done; ok "Enabled at boot"; }
+disable() { need_root; for svc in $(tunnel_services); do systemctl disable "$svc"; done; ok "Disabled at boot"; }
 
 logs() {
-  journalctl -u libersuite -u dnstt -f
+  local journal_args="-u libersuite"
+  load_conf 2>/dev/null || true
+  use_dnstt && journal_args="$journal_args -u dnstt"
+  use_slipstream && journal_args="$journal_args -u slipstream"
+  journalctl $journal_args -f
 }
 
 add_client() {
@@ -294,6 +517,7 @@ disable_client() {
 export_profile() {
   load_conf
   parse_domains
+  parse_slipstream_domains
   USERNAME="$1"
   IP="$2"
 
@@ -306,26 +530,29 @@ export_profile() {
     ok "Detected server IP: $IP"
   fi
 
-  if [[ ! -f "$DNSTT_DIR/server.pub" ]]; then
-      err "Public key not found: $DNSTT_DIR/server.pub"
-  fi
-
-  PUBKEY="$(cat "$DNSTT_DIR/server.pub")"
-
-  if [[ ${#DOMAINS[@]} -eq 0 ]]; then
-      err "No domains available in DOMAINS array"
-  fi
-  PRIMARY_DOMAIN="${DOMAINS[0]}"
-
   ARGS=(
     "client" "export" "$USERNAME"
     "--host" "$IP"
     "--port" "$LIBERSUITE_PORT"
     "--token" "$STATIC_TOKEN"
     "--label" "$USERNAME"
-    "--domain" "$PRIMARY_DOMAIN"
-    "--pubkey" "$PUBKEY"
   )
+
+  if use_dnstt && [[ ${#DOMAINS[@]} -gt 0 ]]; then
+    if [[ -f "$DNSTT_DIR/server.pub" ]]; then
+      PUBKEY="$(cat "$DNSTT_DIR/server.pub")"
+      ARGS+=("--domain" "${DOMAINS[0]}" "--pubkey" "$PUBKEY")
+    else
+      warn "DNSTT public key not found: $DNSTT_DIR/server.pub"
+    fi
+  fi
+
+  if use_slipstream && [[ ${#SLIPSTREAM_DOMAINS[@]} -gt 0 ]]; then
+    ARGS+=("--slipstream-domain" "${SLIPSTREAM_DOMAINS[0]}")
+    if [[ -f "$SLIPSTREAM_DIR/cert.pem" ]]; then
+      ARGS+=("--slipstream-cert" "$SLIPSTREAM_DIR/cert.pem")
+    fi
+  fi
 
   "$LIBER_BIN" "${ARGS[@]}"
 }
@@ -376,7 +603,8 @@ Commands:
   install                              Run installer
   update                               Update binaries
   uninstall                            Uninstall libersuite
-  domain <name[,name2,...]>            Change domain(s)
+  domain dnstt <name[,name2,...]>      Change DNSTT domain(s)
+  domain slipstream <name[,...]>       Change Slipstream domain(s)
   ports <dnstt> <liber> [ssh] [socks]  Change ports
   start | stop | restart               Control services
   enable | disable                     Enable/disable auto-start
@@ -388,7 +616,7 @@ Client Management:
   client remove <username>      Remove a client
   client enable <username>      Enable a client
   client disable <username>     Disable a client
-  client export <user> [ip]
+  client export <user> [ip]     Export connection info (DNSTT + Slipstream)
 
 For client command help: libersuite client
 
@@ -399,7 +627,7 @@ case "$1" in
   install) install ;;
   update) update ;;
   uninstall) uninstall ;;
-  domain) set_domain "$2" ;;
+  domain) set_domain "$2" "$3" ;;
   ports) set_ports "$2" "$3" "$4" "$5" ;;
   start) start ;;
   stop) stop ;;

--- a/mixedserver/server.go
+++ b/mixedserver/server.go
@@ -107,7 +107,7 @@ func (s *Server) handleConnection(clientConn net.Conn) {
 		targetPort = s.cfg.SOCKSPort
 	}
 
-	targetAddr := fmt.Sprintf("%s:%d", s.cfg.BackendHost, targetPort)
+	targetAddr := net.JoinHostPort(s.cfg.BackendHost, fmt.Sprintf("%d", targetPort))
 	targetConn, err := net.DialTimeout("tcp", targetAddr, 10*time.Second)
 	if err != nil {
 		log.Printf("Mixed dial backend %s failed: %v", targetAddr, err)


### PR DESCRIPTION
- install.sh: tunnel mode selection (dnstt / slipstream / both), downloads slipstream-server binary, generates TLS cert, writes slipstream-runner.sh + systemd unit + watchdog timer
- libersuite.sh: slipstream-aware start/stop/restart/logs/uninstall, domain dnstt|slipstream sub-commands, tunnel_services() helper, write_slipstream_runner(), write_slipstream_watchdog(), slipstream export info in 'client export'
- cmd/panel/server.go: --slipstream-domain and --slipstream-addr flags; merges dnstt + slipstream backends into the DNS dispatcher
- cmd/panel/client.go: slipstream plain-text export (domain, user, pass, cert SHA256 fingerprint); readCertFingerprint() helper
- dnsdispatcher: generalize dnsttUDP -> backendUDP (no behavior change)
- mixedserver: fix pre-existing go vet IPv6 format warning

Watchdog runs every 2 minutes via systemd timer, probes each slipstream-server port with a DNS query, restarts the service if any port is unresponsive.